### PR TITLE
Fix: Fixed email regex

### DIFF
--- a/static/signup.js
+++ b/static/signup.js
@@ -108,7 +108,7 @@ var valid_username=function(username){
     return reg.test(username)
 }
 var valid_email=function(email){
-    var reg = new RegExp("^[a-zA-Z0-9_-\\u4E00-\\u9FFF]+@[a-zA-Z0-9_-]+(.[a-zA-Z0-9_-]+)+$", "g");
+    var reg = new RegExp("^[.a-zA-Z0-9_\\u4E00-\\u9FFF]+(\\+[.a-zA-Z0-9_\\u4E00-\\u9FFF]+)*@[a-zA-Z0-9_-]+(.[a-zA-Z0-9_-]+)+$", "g");
     return reg.test(email)
 }
 var validcheck=function(username, password, agpassword, email){


### PR DESCRIPTION
Currently, the following regex is used to check whether a email address entered by the user is valid:
```
^[a-zA-Z0-9_-\\u4E00-\\u9FFF]+@[a-zA-Z0-9_-]+(.[a-zA-Z0-9_-]+)+$
```
However, there is an error in this expression, which is the `-` before `\\u4E00`.  It makes the range behind it completely useless.
(btw, i wonder if anyone really uses Chinese characters as email addresses)

 And this expression cannot handle addresses containing `.`, even though such addresses are valid. Addresses containing a `+` are also excluded, they are aliases for the non-`+` version:
```
example.name@example.com
example.name+reg@example.com
```
The two addresses above are completely equivalent.

This PR modifies the regular expression to:
```
^[.a-zA-Z0-9_\\u4E00-\\u9FFF]+(\\+[.a-zA-Z0-9_\\u4E00-\\u9FFF]+)*@[a-zA-Z0-9_-]+(.[a-zA-Z0-9_-]+)+$

```
This can fix the above issues.
